### PR TITLE
Added Facebook Instrumentation

### DIFF
--- a/Source/Facebook.Client/FacebookSessionClient.cs
+++ b/Source/Facebook.Client/FacebookSessionClient.cs
@@ -24,6 +24,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Net;
+using System.Reflection;
 #if NETFX_CORE
 using Windows.Security.Authentication.Web;
 #endif
@@ -43,8 +45,63 @@ namespace Facebook.Client
                 throw new ArgumentNullException("appId");
             }
             this.AppId = appId;
+
+#if !(WINDOWS_PHONE)
+            SendAnalyticsWindows(this.AppId);
+#else
+            SendAnalyticsWindowsPhone(this.AppId);
+#endif
         }
 
+
+        private static bool AnalyticsSent = false;
+        private static object AnalyticsLock = new object();
+        
+#if !(WINDOWS_PHONE)
+        async private void SendAnalyticsWindows(string FacebookAppId = null)
+        {
+            try
+            {
+                if (!AnalyticsSent)
+                {
+                    AnalyticsSent = true;
+                    string instrumentationURL = String.Format("https://www.facebook.com/impression.php/?plugin=featured_resources&payload=%7B%22resource%22%3A%22microsoft_csharpsdk%22%2C%22appid%22%3A%22{0}%22%2C%22version%22%3A%22{1}%22%7D",
+                            FacebookAppId == null ? String.Empty : FacebookAppId, typeof(FacebookSessionClient).GetTypeInfo().Assembly.GetName().Version);
+                    
+                    // Send Analytics for Windows 8
+                    System.Net.Http.HttpClient httpClient = new System.Net.Http.HttpClient();
+                    var postResult = await httpClient.PostAsync(instrumentationURL, new System.Net.Http.StringContent(String.Empty));
+                    // examine postResult here to make sure you got back a gif file
+                }
+            }
+            catch { } //ignore all errors
+        }
+
+#else
+        private void SendAnalyticsWindowsPhone(string FacebookAppId = null)
+        {
+            System.Threading.Tasks.Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    if (!AnalyticsSent)
+                    {
+                        AnalyticsSent = true;
+                        string instrumentationURL = String.Format("https://www.facebook.com/impression.php/?plugin=featured_resources&payload=%7B%22resource%22%3A%22microsoft_csharpsdk%22%2C%22appid%22%3A%22{0}%22%2C%22version%22%3A%22{1}%22%7D",
+                                FacebookAppId == null ? String.Empty : FacebookAppId, Assembly.GetExecutingAssembly().GetName().Version);
+
+                        WebClient webClient = new WebClient();
+                        webClient.UploadStringCompleted += (s, e) => { /* Event handler for the post completion*/ };
+
+                        webClient.UploadStringAsync(new Uri(instrumentationURL, UriKind.RelativeOrAbsolute), "POST", String.Empty);
+
+                    }
+
+                }
+                catch { } //ignore all errors
+            });
+        }
+#endif
         public async Task<FacebookSession> LoginAsync()
         {
             return await LoginAsync(null, false);


### PR DESCRIPTION
Because of significant differences between WinPhone and Win8, wrote two separate functions instead of a single one. There is no locking because it is unlikely that someone will attempt to create multiple instances of FacebookSessionClient at one point of time from Win8 and WinPhone8 - and even if they do, we will oversample the instrumentation.
