### PR TITLE
Fixed detection of expired cached token. Fixes #18

### DIFF
--- a/Source/Facebook.Client/FacebookSessionClient.cs
+++ b/Source/Facebook.Client/FacebookSessionClient.cs
@@ -99,7 +99,7 @@ namespace Facebook.Client
                     // Prompt OAuth dialog if force renew is true or
                     // if new permissions are requested or 
                     // if the access token is expired.
-                    if (force || newPermissions || session.Expires > DateTime.UtcNow)
+                    if (force || newPermissions || session.Expires <= DateTime.UtcNow)
                     {
                         var authResult = await PromptOAuthDialog(permissions, WebAuthenticationOptions.None);
                         if (authResult != null)


### PR DESCRIPTION
As mentioned in issue #18, the detection of cached token expiration is wrong such that the login web page is shown every time rather than waiting until the token is expired.

This simple change corrects the date comparison logic
