### PR TITLE
Fixed Login page redirect issue

### DIFF
--- a/Source/Facebook.Client/FacebookSessionClient.cs
+++ b/Source/Facebook.Client/FacebookSessionClient.cs
@@ -46,6 +46,7 @@ namespace Facebook.Client
             this.AppId = appId;
 
             // Send analytics to Facebook
+            //** This should be optional as it affects the privacy status of any app consumingthis framework
             SendAnalytics(appId);
         }
 

--- a/Source/Facebook.Client/LoginPage.xaml.cs
+++ b/Source/Facebook.Client/LoginPage.xaml.cs
@@ -101,7 +101,8 @@ namespace Facebook.Client
         /// </summary>
         private void BrowserControl_Navigating(object sender, NavigatingEventArgs e)
         {
-            if (e.Uri == WebAuthenticationBroker.EndUri)
+            //Updated to test only Absolute path as parameters will always be different
+            if (e.Uri.AbsolutePath == WebAuthenticationBroker.EndUri.AbsolutePath)
             {
                 responseData = e.Uri.ToString();
                 responseStatus = WebAuthenticationStatus.Success;


### PR DESCRIPTION
Changed path testing from URI to URI.AbsolutePath
This avoids the issue where the URL will be different for every user / session

Added note about the FaceBook tracking, this should be optional as it affects an apps privacy statement
