### PR TITLE
Call the login callback with fail when you press the close button

### DIFF
--- a/Source/Facebook.Client/Controls/WebDialog/WebDialogUserControl.xaml.cs
+++ b/Source/Facebook.Client/Controls/WebDialog/WebDialogUserControl.xaml.cs
@@ -260,9 +260,9 @@ namespace Facebook.Client.Controls.WebDialog
                 ParentControlPopup.IsOpen = false;
             }
 
-            if (OnDialogFinished != null)
+            if (Session.OnFacebookAuthenticationFinished != null)
             {
-                OnDialogFinished(WebDialogResult.WebDialogResultDialogNotCompleted);
+                Session.OnFacebookAuthenticationFinished(null);
             }
         }
 

--- a/Source/Facebook.Client/Controls/WebDialog/WebDialogUserControl.xaml.cs
+++ b/Source/Facebook.Client/Controls/WebDialog/WebDialogUserControl.xaml.cs
@@ -259,6 +259,11 @@ namespace Facebook.Client.Controls.WebDialog
             {
                 ParentControlPopup.IsOpen = false;
             }
+
+            if (OnDialogFinished != null)
+            {
+                OnDialogFinished(WebDialogResult.WebDialogResultDialogNotCompleted);
+            }
         }
 
         public void LoginViaWebview(Uri startUri)


### PR DESCRIPTION
When you show a WebView login request and the user presses the close button (X) at the top, call the callback with a NotComplete result.